### PR TITLE
auto hide cursor after enter meeting

### DIFF
--- a/public/userscripts/cargo_shorts.js
+++ b/public/userscripts/cargo_shorts.js
@@ -53,6 +53,10 @@
         return document.querySelector(".primaryComputerDialog[style*=\"visible\"] .decisionsHolder button");
     }
 
+    function meetingStage() {
+        return document.querySelector(".stage");
+    }
+
     /********************/
     /* Workflow methods */
     /********************/
@@ -93,6 +97,11 @@
 
     function doJoinMeeting() {
         joinMeetingButton().click(); // FIN
+        waitFor(meetingStage, doHideCursor);
+    }
+
+    function doHideCursor() {
+        document.body.style.cursor = 'none';
     }
 
     /*********************/


### PR DESCRIPTION
For https://github.com/Fryguy/cargo_shorts/issues/9
Test and works in a local web browser browsing bluejeans. Didn't test in the in room system, next time when i'm in office I can test it in room. And maybe help with other issues.  
Also browse and see that stackoverflow page. xdotools is not in fedora dnf repo by default, but this works, may be another option:
```
sudo dnf install xautomation
xte 'mousemove 10000 10000' # any size > screen resolution is okay
```